### PR TITLE
Camp: remove sponsor placeholder

### DIFF
--- a/_layouts/camp-detail.html
+++ b/_layouts/camp-detail.html
@@ -92,7 +92,6 @@
             <a href="{{ post.site }}">
               <img src="{{ post.logo }}" alt="" class="{{ post.class }} sponsor_logo">
             </a>
-            {{ post }}
           </li>
           {% endif %}
           {% endfor %}

--- a/camp/index.html
+++ b/camp/index.html
@@ -54,7 +54,6 @@ root_path:  ../
         <a href="{{ post.site }}">
           <img src="{{ post.logo }}" alt="" class="{{ post.class }} sponsor_logo">
         </a>
-        {{ post }}
       </li>
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
The `{{post}}` placeholder seems to be treated differently locally and on GitHub pages, maybe due to different jekyll versions. On GitHub pages, and entire `<html>` document is pasted into it, which breaks the page