### PR TITLE
fixed link color in attend strip

### DIFF
--- a/camp/index.html
+++ b/camp/index.html
@@ -43,7 +43,7 @@ root_path:  ../
   <a href="https://offlinecamp.typeform.com/to/Tohygh" class="attend">Join Waitlist</a>
   <p>Although we're currently sold out, we <em>highly</em> encourage you to get on our waitlist in case another ticket 
     opens up. Particularly if you identify as a member of a group typically underrepresented at tech events! (See our  
-    <a href="{{ page.root_path }}camp/faq.html#diversity">Diversity Statement</a>.)</p><span>Includes food and lodging.</span>
+    <a href="{{ page.root_path }}camp/faq.html#diversity" style="color:#FF99C6">Diversity Statement</a>.)</p><span>Includes food and lodging.</span>
 </section>
 
 <section class="camp__sponsors">


### PR DESCRIPTION
I used in-line style to force a color change on the Diversity Statement link in the attend strip