### PR TITLE
Pascalcase GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,5 +34,5 @@ root_path:  ./
 
 <p>
   We are collecting discussion results from all of the above on
-  our <a class="" href="https://github.com/offlinefirst">Offline First Github Organisation</a>.
+  our <a class="" href="https://github.com/offlinefirst">Offline First GitHub Organisation</a>.
 </p>


### PR DESCRIPTION
Pascalcase `Github` => `GitHub`. It's a really minor thing, but I just figured I'd point it out! ✨ 