### PR TITLE
Revert "Fixed spacing, added link to camp location vote"

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -17,8 +17,8 @@ tab:        events
     <div>
       <h2>Index</h2>
       <p>San Francisco, CA, USA</p>
-      <p><strong>"Sync for Progressive Web Apps"</strong> (Workshop)</p>
-      <p>Bradley Holt</p>
+      <p><strong>"Sync for Progressive Web Apps"</strong>(Workshop)</p>
+      <p>(Bradley Holt)</p>
     </div>
   </a>
 </article>
@@ -35,8 +35,8 @@ tab:        events
     <div>
       <h2>SXSW</h2>
       <p>Austin, TX, USA</p>
-      <p><strong>"Democratizing Data Science with Offline First"</strong> (Panel)</p>
-      <p>Mathias Buus, Mikel Maron, Raj Singh, Tara Vancil</p>
+      <p><strong>"Democratizing Data Science with Offline First"</strong>(Panel)</p>
+      <p>(Mathias Buus, Mikel Maron, Raj Singh, Tara Vancil)</p>
     </div>
   </a>
 </article>
@@ -54,7 +54,7 @@ tab:        events
       <h2>IBM Think</h2>
       <p>Las Vegas, NV, USA</p>
       <p><strong>"Offline Sync for Progressive Web Apps"</strong></p>
-      <p>Bradley Holt</p>
+      <p>(Bradley Holt)</p>
     </div>
   </a>
 </article>
@@ -69,7 +69,7 @@ tab:        events
     </header>
     <div>
       <h2>Offline Camp</h2>
-      <p>Location TBC (<a href="https://offlinecamp.typeform.com/to/V8aSWJ">Cast your vote here!</a></p>
+      <p>Location TBC</p>
     </div>
   </a>
 </article>


### PR DESCRIPTION
Reverts offlinefirst/offlinefirst.org#194

This made the whole right side of the entry disappear