### PR TITLE
fix(news): replace embedded form with link to GDPR-compliant signup

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -171,11 +171,11 @@ div.clear{
 }
 
 .newsletter {
-  padding: 0 20px;
+  padding: 30px 20px;
   border-bottom: 1px solid #B0CEC9;
 
   background: #E5F7F4;
-  font-size: 18px;
+  font-size: 24px;
   overflow: hidden;
 }
 
@@ -198,7 +198,7 @@ div.clear{
   margin: 0 10px;
 }
 
-.newsletter button {
+.newsletter .button {
   border: none;
   background: #5EC1B4;
 }

--- a/news/index.html
+++ b/news/index.html
@@ -6,21 +6,9 @@ tab:        news
 ---
 
 <div class="newsletter" id="mc_embed_signup">
-  <form action="http://hood.us4.list-manage.com/subscribe/post?u=12d36bbe9418ed6a43127cd62&amp;id=7fc00bfaef" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate="">
-    <p>
-      Get Offline First Reader in your Inbox!
-    </p>
-
-    <p>
-      <label for="input-email">
-        E-mail
-      </label>
-      <input type="email" name="EMAIL" id="input-email" required="">
-      <button type="submit" title="submit">
-        &rarr;
-      </button>
-    </p>
-  </form>
+  <a href="http://eepurl.com/QxUlz">
+    Get the monthly Offline First Reader in your Inbox! &rarr;
+  </a>
 </div><!-- /.newsletter -->
 
 <article class="event">


### PR DESCRIPTION
GDPR requires explicit consent to something specific, so double-opt-in apparently isn’t enough. This replaces the previous embedded form (which can’t support GDPR) with a link to [a new, GDPR-compliant form hosted by Mailchimp](http://eepurl.com/QxUlz), which also links to _their_ privacy policy. 

Hope this is useful! 👋 