### PR TITLE
Close registration for Offline Camp Oregon 2019

### DIFF
--- a/_layouts/camp-detail.html
+++ b/_layouts/camp-detail.html
@@ -77,9 +77,10 @@
       {{ content }}
     </div>
     <section class="attend__strip">
-    <span class="price">$500</span>
+    <span class="price"></span>
     <a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend">Join a Future Camp</a>
-    <p>$500 ticket includes food and lodging.<br/><a href="{{ page.root_path }}camp/faq.html#scholarships" class="pink">Scholarships available.</a></p>
+    <p>Offline Camp Oregon is sold out, but we'd love to see you at our next event! Share your contact details and
+    we'll let you know when the next camp location is announced.</p>
     </section>
 
 
@@ -161,8 +162,9 @@
 
     <footer>
       <section class="tickets">
-        <p>$500 ticket includes food and lodging. <a href= "{{ page.root_path }}camp/faq.html#scholarships">Scholarships available.</a></p>
-        <a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend pink">Apply</a>
+        <p>Offline Camp Oregon is sold out, but we'd love to see you at our next event! Share your contact details and
+        we'll let you know when the next camp location is announced.</p>
+        <a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend pink">Join a Future Camp</a>
       </section>
 
 

--- a/_layouts/camp-detail.html
+++ b/_layouts/camp-detail.html
@@ -66,7 +66,7 @@
               <li{% if page.tab == 'faq' %} class="active"{% endif %}><a href="{{ page.root_path }}camp/faq.html">FAQ</a></li>
               <li{% if page.tab == 'team' %} class="active"{% endif %}><a href="{{ page.root_path }}camp/team.html">Team</a></li>
               <li{% if page.tab == 'coc' %} class="active"{% endif %}><a href="{{ page.root_path }}camp/codeofconduct.html">Conduct</a></li>
-              <li><a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend pink">Apply</a></li>
+              <li><a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend pink">Join a Future Camp</a></li>
             </ul>
           </nav>
         </header>
@@ -78,7 +78,7 @@
     </div>
     <section class="attend__strip">
     <span class="price">$500</span>
-    <a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend">Apply</a>
+    <a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend">Join a Future Camp</a>
     <p>$500 ticket includes food and lodging.<br/><a href="{{ page.root_path }}camp/faq.html#scholarships" class="pink">Scholarships available.</a></p>
     </section>
 

--- a/_layouts/camp-index.html
+++ b/_layouts/camp-index.html
@@ -66,7 +66,7 @@
               <li{% if page.tab == 'faq' %} class="active"{% endif %}><a href="{{ page.root_path }}camp/faq.html">FAQ</a></li>
               <li{% if page.tab == 'team' %} class="active"{% endif %}><a href="{{ page.root_path }}camp/team.html">Team</a></li>
               <li{% if page.tab == 'coc' %} class="active"{% endif %}><a href="{{ page.root_path }}camp/codeofconduct.html">Conduct</a></li>
-              <li><a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend pink">Apply</a></li>
+              <li><a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend pink">Join a Future Camp</a></li>
             </ul>
           </nav>
         </header>

--- a/camp/faq.html
+++ b/camp/faq.html
@@ -23,7 +23,7 @@ root_path:  ../
 
   <h3>When and where is the next Offline Camp?</h3>
 
-  <p>Offline Camp Oregon 2019 will take place in Grants Pass, Oregon from September 27-30, 2019. (For the health and safety of our campers during the Milepost 97 wildfire, we've postponed the event, which was previously scheduled for August 2-5. <a href="{{ page.root_path }}camp/reschedule">See our detailed announcement.</a>)</p>
+  <p>Offline Camp Oregon 2019 will take place in Grants Pass, Oregon from September 27-30, 2019. Registration for the event has closed.</p>
 
   <h3>What if I can't make it?</h3>
   <p>We're working on plans for future iterations of Offline Camp, but we need your
@@ -142,6 +142,8 @@ root_path:  ../
   <a name="applications"></a>
   <h2>Our Campers and the Application Process</h2>
 
+  <p><em>Registration for Offline Camp Oregon is closed, but we'd love to see you at our next event! <a href="https://offlinecamp.typeform.com/to/V8aSWJ">Share your contact details</a> and we'll let you know when the next camp location is announced.</em></p>
+
   <h3>Who is Offline Camp intended for? </h3>
 
   <p>Offline Camp attendees share a common interest in exploring the challenges of building technology that works in poor network conditions. Some of our campers have been building Offline First solutions for years and some are excited to explore these concepts for the first time. Although many of our participants have a technical background, their roles and technical proficiencies vary. Campers might be developing apps, designing user experiences, managing a product, improving a web browser or technical platform, providing humanitarian services to a community with poor connectivity, or supporting the growth of the Offline First community. The discussions we have at camp are meant to propel the community forward, and we hope all of our campers will be in a position to actively contribute to discussions, walk away with a broader perspective, and have a positive impact on the movement when they return home.</p>
@@ -152,7 +154,7 @@ root_path:  ../
 
   <h3>How does the application process work?</h3>
 
-  <p>Interested in attending Offline Camp? You'll start the process by filling out our <a href="https://offlinecamp.typeform.com/to/q93H7U">Camp Application & Scholarship Request Form</a>.</p>
+  <p>Interested in attending Offline Camp? You'll start the process by filling out our Camp Application & Scholarship Request Form.</p>
 
   <p><strong>We strongly encourage you to apply as soon as possible, as we expect the event to sell out.</strong> (Plus, the campers who apply first get the biggest beds!)</p>
 

--- a/camp/index.html
+++ b/camp/index.html
@@ -38,9 +38,10 @@ root_path:  ../
 </section>
 
 <section class="attend__strip">
-    <span class="price">$500</span>
+    <span class="price"></span>
      <a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend">Join a Future Camp</a>
-     <p>$500 ticket includes food and lodging. <br/><a href="{{ page.root_path }}camp/faq.html#scholarships" class="pink">Scholarships available.</a></p>
+     <p>Offline Camp Oregon is sold out, but we'd love to see you at our next event! Share your contact details and
+     we'll let you know when the next camp location is announced.</a></p>
 </section>
 
 <section class="camp__sponsors">
@@ -122,7 +123,8 @@ root_path:  ../
 
 <footer>
   <section class="tickets">
-    <p>$500 ticket includes food and lodging. <a href= "{{ page.root_path }}camp/faq.html#scholarships">Scholarships available.</a></p>
+    <p>Offline Camp Oregon is sold out, but we'd love to see you at our next event! Share your contact details and
+    we'll let you know when the next camp location is announced.</p>
   <a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend pink">Join a Future Camp</a>
   </section>
 

--- a/camp/index.html
+++ b/camp/index.html
@@ -39,7 +39,7 @@ root_path:  ../
 
 <section class="attend__strip">
     <span class="price">$500</span>
-     <a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend">Apply</a>
+     <a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend">Join a Future Camp</a>
      <p>$500 ticket includes food and lodging. <br/><a href="{{ page.root_path }}camp/faq.html#scholarships" class="pink">Scholarships available.</a></p>
 </section>
 
@@ -123,7 +123,7 @@ root_path:  ../
 <footer>
   <section class="tickets">
     <p>$500 ticket includes food and lodging. <a href= "{{ page.root_path }}camp/faq.html#scholarships">Scholarships available.</a></p>
-  <a href="https://offlinecamp.typeform.com/to/q93H7U" class="attend pink">Apply</a>
+  <a href="https://offlinecamp.typeform.com/to/V8aSWJ" class="attend pink">Join a Future Camp</a>
   </section>
 
   <div class="camp__wrapper">


### PR DESCRIPTION
Closing registration and changing "Apply" links to go to the interest form instead.